### PR TITLE
Change to cluster scoped operator

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -199,13 +199,9 @@ func serveCRMetrics(cfg *rest.Config) error {
 	if err != nil {
 		return err
 	}
-	// Get the namespace the operator is currently deployed in.
-	operatorNs, err := k8sutil.GetOperatorNamespace()
-	if err != nil {
-		return err
-	}
+
 	// To generate metrics in other namespaces, add the values below.
-	ns := []string{operatorNs}
+	ns := []string{""}
 	// Generate and serve custom resource specific metrics.
 	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
 	if err != nil {

--- a/deploy/crds/operator.ibm.com_certmanagers_crd.yaml
+++ b/deploy/crds/operator.ibm.com_certmanagers_crd.yaml
@@ -9,7 +9,7 @@ spec:
     listKind: CertManagerList
     plural: certmanagers
     singular: certmanager
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,13 +22,11 @@ spec:
           command:
           - ibm-cert-manager-operator
           args:
-          - --zap-level=0
+          - --zap-level=1
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Changes implemented to have cert-manager-operator be cluster scoped.
- Removes manual deletion of resources when an instance of CertManager CR is being deleted
- Watches and sets controller reference to the instance of the CertManager CR for all resources 
- Adjustments to the CertManager CRD to make it cluster scoped
- Adjustments to the operator deployment spec to make it cluster scoped